### PR TITLE
Remove Py3.6 and pypy3 runner support, add Py3.10 support

### DIFF
--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: Linux CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
     name: Linux CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: Linux CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: macOS CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
     name: macOS CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: macOS CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: Windows CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
     name: Windows CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: Windows CI
     steps:
       - name: Check out source repository


### PR DESCRIPTION
Modifies the CI tests accordingly

Edit: there is a problem with actions/setup-python pypy3 installs in the GHA environment right now.  We will eliminate the pypy3 tests until they fix it. https://github.com/py-actions/py-dependency-install/pull/110/commits/6d19a1244dec27aee76cf19bbe3a7d1f20350dc6