### PR TITLE
Also update packaging python package by default

### DIFF
--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -32,4 +32,5 @@ jobs:
           path: "tests/requirements.txt"
           update-pip: "false"
           update-setuptools: "false"
+          update-packaging: "false"
           update-wheel: "false"

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -32,4 +32,5 @@ jobs:
           path: "tests/requirements.txt"
           update-pip: "false"
           update-setuptools: "false"
+          update-packaging: "false"
           update-wheel: "false"

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -32,4 +32,5 @@ jobs:
           path: "tests/requirements.txt"
           update-pip: "false"
           update-setuptools: "false"
+          update-packaging: "false"
           update-wheel: "false"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ steps:
 
 ### Toggle `pip`, `setuptools`, and `wheel` installs/updates off
 
-The `pip`, `setuptools`, and `wheel` install/updates can be toggled off in your configuration. Use one or more of the `update-pip`, `update-setuptools`, and `update-wheel` settings with a boolean string to customize the default behavior:
+The `pip`, `setuptools`, `packaging`, and `wheel` install/updates can be toggled off in your configuration. Use one or more of the `update-pip`, `update-setuptools`, `update-packaging`, and `update-wheel` settings with a boolean string to customize the default behavior:
 
 ```yaml
 steps:
@@ -51,6 +51,7 @@ steps:
     with:
       update-pip: "false"
       update-setuptools: "false"
+      update-packaging: "false"
       update-wheel: "false"
 ```
 
@@ -65,6 +66,10 @@ steps:
 **Optional** A boolean string indicating that a `pip` package update should occur before the dependency installation. Options: [`"true"`, `"false"`].  Default=`"true"`
 
 ### `update-setuptools`
+
+**Optional** A boolean string indicating that a `pip` package update should occur before the dependency installation. Options: [`"true"`, `"false"`].  Default=`"true"`
+
+### `update-packaging`
 
 **Optional** A boolean string indicating that a `setuptools` package update should occur before the dependency installation. Options: [`"true"`, `"false"`].  Default=`"true"`
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Boolean for setuptools install/upgrade prior to the dependency installation (default='true')"
     required: false
     default: "true" # options "true", "false"
+  update-packaging:
+    description: "Boolean for packaging install/upgrade prior to the dependency installation (default='true')"
+    required: false
+    default: "true" # options "true", "false"
   update-wheel:
     description: "Boolean for wheel install/upgrade prior to the dependency installation (default='true')"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -27145,7 +27145,7 @@ module.exports = require("zlib");
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -27159,7 +27159,7 @@ module.exports = require("zlib");
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -27168,16 +27168,16 @@ module.exports = require("zlib");
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
@@ -27189,6 +27189,7 @@ async function run() {
   const requirementsPath = core.getInput("path");
   const updatePip = core.getInput("update-pip");
   const updateSetuptools = core.getInput("update-setuptools");
+  const updatePackaging = core.getInput("update-packaging");
   const updateWheel = core.getInput("update-wheel");
 
   // ====================
@@ -27204,6 +27205,11 @@ async function run() {
     if (updateSetuptools === "true") {
       console.log("[*] Updating setuptools package...");
       await exec.exec("python -m pip install --upgrade setuptools");
+    }
+    // update packaging
+    if (updatePackaging === "true") {
+      console.log("[*] Updating packaging package...");
+      await exec.exec("python -m pip install --upgrade packaging");
     }
     // update pip
     if (updatePip === "true") {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ async function run() {
   const requirementsPath = core.getInput("path");
   const updatePip = core.getInput("update-pip");
   const updateSetuptools = core.getInput("update-setuptools");
+  const updatePackaging = core.getInput("update-packaging");
   const updateWheel = core.getInput("update-wheel");
 
   // ====================
@@ -20,6 +21,11 @@ async function run() {
     if (updateSetuptools === "true") {
       console.log("[*] Updating setuptools package...");
       await exec.exec("python -m pip install --upgrade setuptools");
+    }
+    // update packaging
+    if (updateSetuptools === "true") {
+      console.log("[*] Updating packaging package...");
+      await exec.exec("python -m pip install --upgrade packaging");
     }
     // update pip
     if (updatePip === "true") {


### PR DESCRIPTION
When updating setuptools without packaging and installing certain versions of python packages there can be errors because of incompatibility.

For reference I had to juggle around with this exact issue because our CI broke here:
https://github.com/PX4/PX4-Autopilot/pull/23991

I thought I'd rather upstream the solution than keep my local workaround.